### PR TITLE
fix "security_inode_copy_up" example in docs

### DIFF
--- a/docs/content/en/docs/concepts/tracing-policy/hooks.md
+++ b/docs/content/en/docs/concepts/tracing-policy/hooks.md
@@ -592,6 +592,7 @@ metadata:
 spec:
   kprobes:
   - call: "security_inode_copy_up"
+    syscall: false
     args:
     - index: 0 # struct dentry *src
       type: "int64"


### PR DESCRIPTION
Hi!

### Description

As discussed [in Slack](https://cilium.slack.com/archives/C03EV7KJPJ9/p1751961517515919?thread_ts=1751631795.554419&cid=C03EV7KJPJ9), one of the Tracing Policy examples in the docs is broken: hooking "security_inode_copy_up" requires the "syscall: false" clause, as this function is not a syscall.

This PR simply adds `syscall: false` to the example code.